### PR TITLE
Add Discord instruction lessons research packet

### DIFF
--- a/research/2026-04-16-discord-instruction-lessons/00-scope-and-method.md
+++ b/research/2026-04-16-discord-instruction-lessons/00-scope-and-method.md
@@ -1,0 +1,46 @@
+# Scope and Method
+
+## What was reviewed
+
+I reviewed current and archived on-disk session transcripts under `~/.openclaw/agents/main/sessions/`, including:
+
+- active `.jsonl` session files
+- archived `.jsonl.reset.*` files
+- archived `.jsonl.deleted.*` files where relevant
+
+## Discord channels verified in scope
+
+Core channels with meaningful instruction/process lessons:
+
+- `#cass-inbox`
+- `#car-shopping`
+- `#agent-improvements`
+- `#general`
+- `#knowledge-graphs`
+- `#lesson-plans`
+- `#lesson-plans-2`
+- `#chris-stories`
+- `#remarq`
+
+Other Discord channels existed, but the strongest instruction-learning density lived in the set above.
+
+## What counted as an "instruction lesson"
+
+A lesson was included when one of these happened:
+
+- Chris or Serena explicitly corrected behavior
+- a new default was established
+- a file-backed rule was added or clarified in workspace instructions
+- a repeated failure mode showed that the current instruction layer was too weak
+- a runtime/config fix taught a better operating rule than the previous one
+
+## What did not count
+
+- routine task execution with no generalizable lesson
+- one-off domain facts
+- generic praise or reaction without process change
+
+## Summary judgment standard
+
+The goal was not "what happened in each chat".
+The goal was "what persistent operating rules led to better outcomes later".

--- a/research/2026-04-16-discord-instruction-lessons/README.md
+++ b/research/2026-04-16-discord-instruction-lessons/README.md
@@ -1,0 +1,23 @@
+# Discord Instruction Lessons Review
+
+Date: 2026-04-16
+Scope: Discord session transcripts from 2026-02-27 through 2026-04-16
+Repo purpose: preserve what we learned, channel by channel, about improving Cass's instructions and operating rules for better outcomes.
+
+## Folder map
+
+- `00-scope-and-method.md` — what was reviewed and how
+- `channels/` — per-channel systematic summaries
+- `cross-cutting/01-core-lessons.md` — the main cross-channel synthesis
+- `cross-cutting/02-tweet-cards.md` — short bullets/cards for tweet digestion
+- `cross-cutting/03-long-form-article-opportunities.md` — article ideas and counts
+- `digest.md` — single-file executive digest
+
+## Verified date range
+
+- Earliest Discord transcript found: 2026-02-27 (`#cass-inbox`)
+- Latest Discord transcript reviewed: 2026-04-16
+
+## Main conclusion
+
+The strongest instruction upgrades were not vague style tweaks. They were operational changes that tightened what "done" means, reduced agent wandering, improved runtime correctness, and made output immediately usable.

--- a/research/2026-04-16-discord-instruction-lessons/README.md
+++ b/research/2026-04-16-discord-instruction-lessons/README.md
@@ -11,6 +11,7 @@ Repo purpose: preserve what we learned, channel by channel, about improving Cass
 - `cross-cutting/01-core-lessons.md` — the main cross-channel synthesis
 - `cross-cutting/02-tweet-cards.md` — short bullets/cards for tweet digestion
 - `cross-cutting/03-long-form-article-opportunities.md` — article ideas and counts
+- `cross-cutting/04-beginner-practical-framing.md` — practical framing for readers with no agentic background
 - `digest.md` — single-file executive digest
 
 ## Verified date range

--- a/research/2026-04-16-discord-instruction-lessons/channels/01-cass-inbox.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/01-cass-inbox.md
@@ -1,0 +1,42 @@
+# Channel Summary: #cass-inbox
+
+## Date coverage
+- 2026-02-27 to 2026-03-28 verified from archived Discord session transcripts
+
+## Why this channel mattered
+This was one of the earliest operational channels, so it exposed first-generation workflow rules around triage, inbox handling, and routing work into the right systems.
+
+## Main lessons learned
+
+### 1. Inbox channels need explicit triage rules
+What improved:
+- autonomous tasks should be handled directly
+- Chris-only tasks should go to his task system
+- reminders should become cron jobs
+- reference material should be logged, not left loose in chat
+
+Why it mattered:
+- this turned a random dumping ground into a structured intake surface
+- it reduced dropped tasks and reduced ambiguity about where things belong
+
+### 2. Forwarded email handling needed a real operating model
+What improved:
+- watch only the right sender path
+- process the inbox continuously
+- mark and route items intentionally instead of just acknowledging them
+
+Why it mattered:
+- made inbox processing trustworthy
+- established that operational email intake needs a deterministic workflow, not ad hoc checking
+
+### 3. Output quality improved when content was rewritten to match Chris's actual voice
+What improved:
+- content got less polished-and-preachy
+- style guides became useful constraints rather than decorative docs
+
+Why it mattered:
+- early drafts sounded generic until grounded in an explicit voice guide
+- this helped content become publishable instead of merely coherent
+
+## Durable rule from this channel
+- Every intake surface needs a routing contract, not just a response habit.

--- a/research/2026-04-16-discord-instruction-lessons/channels/02-car-shopping.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/02-car-shopping.md
@@ -1,0 +1,38 @@
+# Channel Summary: #car-shopping
+
+## Date coverage
+- 2026-03-06 to 2026-03-09 verified from archived Discord session transcripts
+
+## Why this channel mattered
+This channel surfaced research-quality lessons, especially around verification and uncertainty handling.
+
+## Main lessons learned
+
+### 1. Asking prices are not reality
+What improved:
+- shifted from reporting scraped listing prices to distinguishing asking price from actual market behavior
+- used contradictory evidence as a signal to investigate deeper, not something to hand-wave away
+
+Why it mattered:
+- improved decision usefulness
+- reduced false precision in purchase advice
+
+### 2. When a listing cannot be verified, say so plainly
+What improved:
+- direct admission when a specific listing URL or price could not be verified live
+- stopped treating stale search results as hard facts
+
+Why it mattered:
+- built trust
+- prevented brittle recommendations based on unverifiable inventory
+
+### 3. Good buying research needs synthesis, not just aggregation
+What improved:
+- combined dealer listings, market discussion, and financing structure into one decision frame
+
+Why it mattered:
+- the better outcome was not "more links"
+- it was a more decision-ready explanation of tradeoffs
+
+## Durable rule from this channel
+- For money decisions, explicitly separate verified facts, inferred market dynamics, and uncertainty.

--- a/research/2026-04-16-discord-instruction-lessons/channels/03-agent-improvements.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/03-agent-improvements.md
@@ -1,0 +1,49 @@
+# Channel Summary: #agent-improvements
+
+## Date coverage
+- 2026-04-05 to 2026-04-12 verified from current Discord session transcripts
+
+## Why this channel mattered
+This was the clearest meta-operations channel. It contains direct lessons about instruction design, runtime mistakes, debugging quality, and progress update quality.
+
+## Main lessons learned
+
+### 1. Docs-only fixes are fake fixes
+Observed change:
+- an initial pass replaced Claude Code references in skills/docs, but runtime exposure was still wrong
+- later correction explicitly called out that the real fix required changing runtime/config behavior, not just text
+
+Why it mattered:
+- taught the difference between instruction cosmetics and actual behavioral control
+- prevented repeated regressions where the written rule changed but the live tool path did not
+
+### 2. Debug from actual logs, not vibes
+Observed change:
+- later debugging explicitly checked session/run history instead of guessing why a timeout happened
+- over-broad searches across all logs were identified as their own failure mode
+
+Why it mattered:
+- made debugging faster and more accurate
+- reduced narrative explanations built on the wrong evidence set
+
+### 3. Progress updates need to be sparse and meaningful
+Observed change:
+- the coding-agent guidance emphasized one start message, then updates only on milestone, blocker, error, or finish
+
+Why it mattered:
+- users stop trusting updates when they are constant but low-information
+- concise milestone-only reporting made status messages worth reading
+
+### 4. Tight working scope beats sprawling context
+Observed change:
+- coding-agent guidance increasingly favored focused workdirs, smaller context, and less wandering across unrelated workspace files
+
+Why it mattered:
+- reduced meandering and irrelevant file reads
+- improved completion speed and relevance
+
+## Durable rules from this channel
+- Fix runtime behavior, not just docs.
+- Debug from exact logs.
+- Keep progress updates milestone-based.
+- Constrain scope hard.

--- a/research/2026-04-16-discord-instruction-lessons/channels/04-general-channel-config.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/04-general-channel-config.md
@@ -1,0 +1,37 @@
+# Channel Summary: #general and channel wiring lessons
+
+## Date coverage
+- 2026-04-06 to 2026-04-14 verified from current Discord session transcripts
+
+## Why this channel mattered
+This is where channel-level operating behavior became explicit instead of assumed.
+
+## Main lessons learned
+
+### 1. A new Discord channel is not real until it is wired
+What improved:
+- new channels were added to config and restarted properly
+- response behavior was no longer assumed from mere server membership
+
+Why it mattered:
+- prevented silent deafness
+- made channel availability deterministic
+
+### 2. Mention behavior must be intentional
+What improved:
+- some channels were configured to respond without mentions
+- others later moved toward requiring mentions
+
+Why it mattered:
+- channel norms differ
+- explicit mention policy prevents accidental spam or accidental silence
+
+### 3. Channel setup is operational work, not metadata
+What improved:
+- channel creation plus config patch plus verification became the real checklist
+
+Why it mattered:
+- this closed the gap between "channel exists" and "assistant can actually behave correctly there"
+
+## Durable rule from this channel
+- Treat channel wiring and mention policy as first-class operating rules.

--- a/research/2026-04-16-discord-instruction-lessons/channels/05-knowledge-graphs.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/05-knowledge-graphs.md
@@ -1,0 +1,37 @@
+# Channel Summary: #knowledge-graphs
+
+## Date coverage
+- 2026-04-07 to 2026-04-10 verified from current Discord session transcripts
+
+## Why this channel mattered
+This channel produced one of the cleanest lessons about delegated work: stalls were often wandering, not crashing.
+
+## Main lessons learned
+
+### 1. "Stalled" often meant "wandering"
+Observed change:
+- direct session-log inspection showed Pi was re-reading `SOUL.md`, `USER.md`, memory files, and unrelated workspace content instead of advancing the assigned chunk
+
+Why it mattered:
+- changed the diagnosis from vague slowness to a concrete failure mode
+- made the remedy obvious: narrow scope, redirect architecture, or take over directly
+
+### 2. Architecture should converge early
+Observed change:
+- after the wandering diagnosis, recommendations shifted toward a Logseq-native, markdown-first architecture rather than over-building the system too early
+
+Why it mattered:
+- reduced speculative complexity
+- gave the work a clearer source-of-truth model
+
+### 3. Delegates need intervention rules
+Observed change:
+- child sessions were used in parallel, but the transcripts showed the need for better steering when delegated work drifts
+
+Why it mattered:
+- without intervention rules, delegation becomes a delay multiplier
+
+## Durable rules from this channel
+- When a delegate stalls, inspect the log before speculating.
+- Wandering is a distinct failure mode.
+- Narrow context and re-scope early.

--- a/research/2026-04-16-discord-instruction-lessons/channels/06-lesson-plans.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/06-lesson-plans.md
@@ -1,0 +1,38 @@
+# Channel Summary: #lesson-plans
+
+## Date coverage
+- 2026-04-05 to 2026-04-13 verified from current Discord session transcripts
+
+## Why this channel mattered
+This was the first dense Little Lab Coats quality channel. It revealed that lesson output needed much stricter completeness and usability standards.
+
+## Main lessons learned
+
+### 1. Completeness bugs must be treated as real product failures
+Observed change:
+- lesson/unit mismatches were explicitly called out and folded into a completeness pass
+- partial libraries stopped being treated as "basically done"
+
+Why it mattered:
+- curriculum trust depends on internal consistency
+- gaps in unit structure break the product, not just the polish
+
+### 2. Honest status beats fake finish
+Observed change:
+- updates began distinguishing confirmed fixes from known unresolved gaps
+
+Why it mattered:
+- preserved trust with Serena
+- made next actions obvious
+
+### 3. LLC quality depends on teaching usability, not just page generation
+Observed change:
+- lessons increasingly optimized around parent usability, household materials, and classroom flow rather than generic content volume
+
+Why it mattered:
+- turned pages into teachable materials instead of just long HTML documents
+
+## Durable rules from this channel
+- Completeness is product quality.
+- Status should separate fixed, known-broken, and next-to-fix.
+- Teaching usability matters more than raw content length.

--- a/research/2026-04-16-discord-instruction-lessons/channels/07-lesson-plans-2.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/07-lesson-plans-2.md
@@ -1,0 +1,62 @@
+# Channel Summary: #lesson-plans-2
+
+## Date coverage
+- 2026-04-12 to 2026-04-15 verified from current Discord session transcripts
+
+## Why this channel mattered
+This was the highest-density channel for instruction hardening around deliverables, review workflows, links, preview gates, and what "done" actually means.
+
+## Main lessons learned
+
+### 1. Always include the usable link
+Observed change:
+- explicit promise: when a lesson revision finished, the direct revised lesson link would be pasted into the channel
+- later, this became a broader rule to include the link automatically when the deliverable needs one
+
+Why it mattered:
+- removed a whole class of frustrating follow-up questions
+- made completion messages immediately actionable
+
+### 2. Review-ready and publish-ready are different states
+Observed change:
+- review mode, reviewer council, and live review paths became explicit requirements before anything was described as fully ready
+
+Why it mattered:
+- prevented premature claims of completion
+- aligned the work with actual stakeholder review flow
+
+### 3. The preview window must be meaningful
+Observed change:
+- previews were explicitly extended through the Learning Objectives section instead of being cut off too early
+
+Why it mattered:
+- improved product conversion logic
+- made public pages useful enough to evaluate before subscription
+
+### 4. Remarq wiring must use real document IDs
+Observed change:
+- lesson workflows increasingly required explicit real Remarq document IDs rather than placeholders or assumptions
+
+Why it mattered:
+- prevented fake-integrated pages
+- made review feedback operational instead of decorative
+
+### 5. "Done" means live, verified, and reviewable
+Observed change:
+- live links, public-path checks, review mode verification, and commit/push became part of the definition of done
+
+Why it mattered:
+- transformed deliverables from local progress into actually shippable outcomes
+
+### 6. Mention policy also matters at the channel level
+Observed change:
+- this channel later moved toward requiring mention behavior explicitly
+
+Why it mattered:
+- reduced accidental interruption in a high-volume review channel
+
+## Durable rules from this channel
+- Include direct links automatically.
+- Keep review-ready separate from publish-ready.
+- Make previews meaningful.
+- Treat integration as incomplete until real IDs and live checks exist.

--- a/research/2026-04-16-discord-instruction-lessons/channels/08-chris-stories.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/08-chris-stories.md
@@ -1,0 +1,37 @@
+# Channel Summary: #chris-stories
+
+## Date coverage
+- 2026-04-05 to 2026-04-12 verified from current Discord session transcripts
+
+## Why this channel mattered
+This channel shows how content-generation quality improved once the system moved from generic prompting to structured coverage, voice, and gap tracking.
+
+## Main lessons learned
+
+### 1. Question selection should be coverage-driven, not improvisational
+Observed change:
+- introduction of a questions log and a gap tracker to avoid repeats and fill real biography gaps
+
+Why it mattered:
+- improved long-run coherence
+- reduced wandering prompts and repetitive questioning
+
+### 2. Voice guides are multiplicative constraints
+Observed change:
+- explicit writing guides for Chris and Serena were introduced to shape narrative output
+
+Why it mattered:
+- made drafts sound more like the actual people involved
+- turned biographies from generic summaries into voice-aware material
+
+### 3. Systematic memory scaffolding beats loose recall
+Observed change:
+- story work became organized around known coverage, missing coverage, and voice constraints
+
+Why it mattered:
+- made the channel cumulative instead of episodic
+
+## Durable rules from this channel
+- Track coverage gaps explicitly.
+- Maintain question logs.
+- Use voice guides when narrative fidelity matters.

--- a/research/2026-04-16-discord-instruction-lessons/channels/09-remarq-and-runtime.md
+++ b/research/2026-04-16-discord-instruction-lessons/channels/09-remarq-and-runtime.md
@@ -1,0 +1,37 @@
+# Channel Summary: #remarq and repository-backed instruction changes
+
+## Date coverage
+- 2026-04-07 to 2026-04-16 verified from current Discord session transcripts and workspace git history
+
+## Why this channel mattered
+This channel connected session lessons to durable instruction artifacts in git.
+
+## Key repo-backed changes observed
+
+- 2026-04-07: require explicit Remarq document IDs
+- 2026-04-07: require git push for business-critical changes
+- 2026-04-10: document LLC deploy propagation verification
+- 2026-03-15: move static file server root to `public/`
+- 2026-03-15: replace Claude Code with Pi as default coding agent
+- 2026-02-27: logseq journal-first convention and updated Chris working preferences
+- 2026-02-22: add premortem thinking to `SOUL.md`
+- 2026-02-04: auto-commit workflow and no-force-push rules
+
+## Main lessons learned
+
+### 1. The best lessons were codified, not just remembered
+When a lesson moved into `AGENTS.md`, `SOUL.md`, `USER.md`, or `TOOLS.md`, it stopped being a chat anecdote and became durable behavior.
+
+### 2. Operational rules outperform style-only rules
+The best repo-backed changes were concrete:
+- verify deploy propagation
+- include links
+- push business-critical work
+- use explicit IDs
+- preserve main history
+
+### 3. Repo history is part of instruction memory
+Git commits created a second evidence trail showing which lessons were important enough to formalize.
+
+## Durable rule from this channel
+- If a lesson materially improves outcomes, write it into the operating files and commit it.

--- a/research/2026-04-16-discord-instruction-lessons/cross-cutting/01-core-lessons.md
+++ b/research/2026-04-16-discord-instruction-lessons/cross-cutting/01-core-lessons.md
@@ -1,0 +1,55 @@
+# Cross-Cutting Lessons
+
+## 1. Replace aspirational instructions with operational ones
+The big upgrade across channels was moving from soft guidance like "be helpful" to hard rules like:
+- include the direct link automatically
+- verify the live path
+- treat business-critical work as incomplete until committed and pushed
+- debug from actual logs
+- use explicit IDs
+
+## 2. Tighten the definition of done
+A recurring improvement pattern was upgrading done from:
+- progress made
+
+to:
+- artifact created
+- live path or usable file verified
+- link included
+- integration confirmed
+- commit and push completed when relevant
+
+## 3. Verification beats confidence
+The most valuable corrections came from checking:
+- exact logs
+- exact live pages
+- exact session history
+- exact runtime config
+
+## 4. Delegation needs boundaries
+Delegates improved outcomes when the scope was narrow.
+They degraded outcomes when they wandered across the whole workspace or kept reading context instead of acting.
+
+## 5. Channel behavior is part of product behavior
+Several issues were not model-intelligence issues at all. They were routing, mention policy, or channel wiring issues.
+
+## 6. Reviewability is a first-class quality attribute
+Especially in LLC work, "review-ready" became a real state with rules around:
+- live review links
+- reviewer workflow
+- meaningful previews
+- real Remarq IDs
+
+## 7. Voice and structure matter for content systems
+For stories and content, quality rose when the system tracked:
+- gaps
+- voice
+- coverage map
+- repeat avoidance
+
+## 8. Good status updates are sparse and decisive
+Users benefited most from updates that happened only when:
+- something started
+- a milestone finished
+- a blocker emerged
+- the work was actually done

--- a/research/2026-04-16-discord-instruction-lessons/cross-cutting/02-tweet-cards.md
+++ b/research/2026-04-16-discord-instruction-lessons/cross-cutting/02-tweet-cards.md
@@ -1,0 +1,70 @@
+# Tweet Cards
+
+## Card 1
+- The biggest AI assistant upgrade is not "better prompting."
+- It's replacing vague instructions with operating rules.
+- "Be helpful" is weak.
+- "Ship the artifact, verify it, include the link" changes behavior.
+
+## Card 2
+- Most "agent failures" are not intelligence failures.
+- They're scope failures.
+- Too much context, too many files, too much room to wander.
+- Smaller workdir, smaller prompt, better result.
+
+## Card 3
+- Docs-only fixes are fake fixes.
+- If the runtime still exposes the old behavior, the behavior did not change.
+- Updating the instructions without updating the live path is how systems gaslight you.
+
+## Card 4
+- We learned to stop calling things done when progress was made.
+- Done means:
+- artifact exists
+- public path works
+- link is included
+- reviewers can actually review it
+
+## Card 5
+- A good status update is a compression algorithm.
+- Start, milestone, blocker, finish.
+- Anything else is usually noise.
+
+## Card 6
+- When an agent looks stalled, check the transcript.
+- Half the time it's not crashed.
+- It's wandering.
+- That's a different problem and needs a different fix.
+
+## Card 7
+- "Review-ready" and "publish-ready" are not the same state.
+- Teams that blur them create endless thrash.
+- We got better once we made that boundary explicit.
+
+## Card 8
+- Content quality jumped when we stopped improvising and started tracking:
+- voice
+- coverage gaps
+- repeat avoidance
+- source-of-truth notes
+
+## Card 9
+- New channels don't exist operationally just because you created them.
+- They exist when routing, permissions, mention policy, and verification are done.
+- Channel setup is product work.
+
+## Card 10
+- Research gets dramatically better when you separate:
+- verified facts
+- inferred dynamics
+- open uncertainty
+- Most bad advice mashes all three together.
+
+## Card 11
+- The most durable lessons are the ones that get committed.
+- If it materially improves outcomes, put it in the operating files and push it.
+
+## Card 12
+- The real shift was from personality instructions to execution instructions.
+- Not "sound smart."
+- More like "verify, constrain, ship, link, commit."

--- a/research/2026-04-16-discord-instruction-lessons/cross-cutting/03-long-form-article-opportunities.md
+++ b/research/2026-04-16-discord-instruction-lessons/cross-cutting/03-long-form-article-opportunities.md
@@ -1,0 +1,65 @@
+# Long-Form Article Opportunities
+
+## Count
+I think there are **12 credible long-form article candidates** in this packet.
+
+That count is based on themes that are:
+- distinct enough to support their own essay
+- repeatedly reinforced in the transcripts
+- useful to builders beyond our own setup
+
+## Candidate articles
+
+### 1. Operational prompts beat aspirational prompts
+Angle:
+Why AI systems improve fastest when instructions become executable operating rules.
+
+### 2. The real definition of done for AI-assisted work
+Angle:
+Why artifact + verification + link + commit is a better completion contract than status theater.
+
+### 3. Most agent stalls are scope bugs, not reasoning bugs
+Angle:
+How wandering emerges and how narrower context changes performance.
+
+### 4. Docs-only fixes are fake fixes
+Angle:
+The difference between changing instructions, changing configuration, and changing real behavior.
+
+### 5. How to debug agents without lying to yourself
+Angle:
+Session logs, live pages, and runtime state as the real source of truth.
+
+### 6. Review-ready vs publish-ready
+Angle:
+Why teams need a distinct reviewability state for serious content and product work.
+
+### 7. Building live review systems with explicit IDs and real paths
+Angle:
+What the LLC and Remarq lessons teach about integration honesty.
+
+### 8. Why channel routing is part of the product
+Angle:
+Operational lessons from mention policy, config wiring, and channel-specific behavior.
+
+### 9. The anatomy of a useful status update
+Angle:
+How milestone-based updates outperform constant chatter.
+
+### 10. Voice fidelity as a systems problem
+Angle:
+How gap trackers, voice guides, and question logs improve biography/content generation.
+
+### 11. Research quality comes from uncertainty hygiene
+Angle:
+Separating verified fact from inference in financial or purchase decisions.
+
+### 12. Commit your operating lessons
+Angle:
+Why the best process improvements should become versioned infrastructure, not tribal memory.
+
+## Priority order
+If choosing only 3 to draft first:
+1. Operational prompts beat aspirational prompts
+2. The real definition of done for AI-assisted work
+3. Most agent stalls are scope bugs, not reasoning bugs

--- a/research/2026-04-16-discord-instruction-lessons/cross-cutting/03-long-form-article-opportunities.md
+++ b/research/2026-04-16-discord-instruction-lessons/cross-cutting/03-long-form-article-opportunities.md
@@ -1,65 +1,139 @@
-# Long-Form Article Opportunities
+# Long-Form Article Opportunities, Beginner-Framed
 
 ## Count
 I think there are **12 credible long-form article candidates** in this packet.
 
-That count is based on themes that are:
-- distinct enough to support their own essay
-- repeatedly reinforced in the transcripts
-- useful to builders beyond our own setup
+This time the framing is for a reader with **zero agentic experience** who wants to understand:
+- what this unlocks in normal life or work
+- how to set it up practically
+- which rules matter first
+- how to avoid the common failure modes
 
 ## Candidate articles
 
-### 1. Operational prompts beat aspirational prompts
+### 1. What an AI assistant can actually do once it stops acting like a chatbot
 Angle:
-Why AI systems improve fastest when instructions become executable operating rules.
+Show a newcomer the jump from question-answering to real task ownership: inbox triage, research, reminders, drafting, review flows, and shipping artifacts.
 
-### 2. The real definition of done for AI-assisted work
+Practical spine:
+- what is possible
+- what is not safe to delegate yet
+- the minimum setup needed to get useful results
+
+### 2. The 5 rules that make an AI assistant actually useful in real life
 Angle:
-Why artifact + verification + link + commit is a better completion contract than status theater.
+Explain that most failures come from missing operating rules, not weak models.
 
-### 3. Most agent stalls are scope bugs, not reasoning bugs
+Practical spine:
+- define done
+- require links/artifacts
+- verify before claiming success
+- narrow scope
+- update only on milestones
+
+### 3. How to set up your first agent without building a giant system
 Angle:
-How wandering emerges and how narrower context changes performance.
+A tactical beginner guide to starting small instead of over-engineering.
 
-### 4. Docs-only fixes are fake fixes
+Practical spine:
+- pick one high-friction workflow
+- give the assistant one inbox and one memory location
+- create simple routing rules
+- add only one automation at a time
+
+### 4. Why your AI assistant keeps failing, and the surprisingly boring fixes
 Angle:
-The difference between changing instructions, changing configuration, and changing real behavior.
+For beginners, most failures are not magical. They are usually caused by ambiguous instructions, too much scope, no source of truth, or fake completion criteria.
 
-### 5. How to debug agents without lying to yourself
+Practical spine:
+- common failure patterns
+- how to diagnose each one
+- the smallest fix that usually works
+
+### 5. The real definition of done for AI-assisted work
 Angle:
-Session logs, live pages, and runtime state as the real source of truth.
+Teach newcomers that "worked on it" is useless. The assistant should finish with something usable.
 
-### 6. Review-ready vs publish-ready
+Practical spine:
+- artifact created
+- file or public path verified
+- direct link included
+- next step obvious
+
+### 6. How to keep an AI agent from wandering off into nonsense
 Angle:
-Why teams need a distinct reviewability state for serious content and product work.
+A beginner-friendly explanation of scope drift and why smaller context wins.
 
-### 7. Building live review systems with explicit IDs and real paths
+Practical spine:
+- one task
+- one folder
+- one output
+- one finish condition
+- what to do when the agent starts reading everything in sight
+
+### 7. How to use AI for content without sounding like AI slop
 Angle:
-What the LLC and Remarq lessons teach about integration honesty.
+A practical guide to voice guides, coverage maps, and repeat avoidance for people using assistants to write posts, articles, or family stories.
 
-### 8. Why channel routing is part of the product
+Practical spine:
+- start from real samples
+- define voice constraints
+- track what has already been said
+- keep a gap list
+
+### 8. How to build a review workflow around AI instead of blindly trusting it
 Angle:
-Operational lessons from mention policy, config wiring, and channel-specific behavior.
+Show that useful systems separate draft, review-ready, and publish-ready states.
 
-### 9. The anatomy of a useful status update
+Practical spine:
+- what review-ready means
+- where humans should step in
+- how to leave comments the model can actually act on
+- why this beats one-shot generation
+
+### 9. A practical guide to giving an AI assistant a real operating memory
 Angle:
-How milestone-based updates outperform constant chatter.
+Explain memory not as magic, but as files, notes, logs, and committed rules.
 
-### 10. Voice fidelity as a systems problem
+Practical spine:
+- daily notes vs long-term memory
+- what to write down
+- how operating docs improve future behavior
+- why tribal memory fails
+
+### 10. How to turn Discord, email, or chat into a real command center
 Angle:
-How gap trackers, voice guides, and question logs improve biography/content generation.
+For non-technical users, explain how a channel becomes operational instead of conversational.
 
-### 11. Research quality comes from uncertainty hygiene
+Practical spine:
+- routing rules
+- mention policy
+- what each channel is for
+- how to keep noise from taking over
+
+### 11. How to research with AI without getting fooled by fake confidence
 Angle:
-Separating verified fact from inference in financial or purchase decisions.
+A beginner guide to separating verified facts, inferred conclusions, and open uncertainty.
 
-### 12. Commit your operating lessons
+Practical spine:
+- what to verify directly
+- what to label as inference
+- how to use this for purchases, business decisions, and planning
+
+### 12. The simplest path from solo assistant to lightweight AI operations system
 Angle:
-Why the best process improvements should become versioned infrastructure, not tribal memory.
+Describe the progression from one helpful assistant to a practical personal ops layer.
 
-## Priority order
-If choosing only 3 to draft first:
-1. Operational prompts beat aspirational prompts
-2. The real definition of done for AI-assisted work
-3. Most agent stalls are scope bugs, not reasoning bugs
+Practical spine:
+- start with one workflow
+- add memory
+- add routing
+- add review
+- add automation only after the manual loop works
+
+## Best first 5 for this new framing
+1. What an AI assistant can actually do once it stops acting like a chatbot
+2. The 5 rules that make an AI assistant actually useful in real life
+3. How to set up your first agent without building a giant system
+4. The real definition of done for AI-assisted work
+5. How to keep an AI agent from wandering off into nonsense

--- a/research/2026-04-16-discord-instruction-lessons/cross-cutting/04-beginner-practical-framing.md
+++ b/research/2026-04-16-discord-instruction-lessons/cross-cutting/04-beginner-practical-framing.md
@@ -1,0 +1,103 @@
+# Beginner Practical Framing
+
+## The right audience for this packet
+This reframing is for someone who has little or no agentic experience and wants to understand:
+- what AI assistants can realistically do
+- what setup matters first
+- what to avoid
+- how to get practical value without building a giant system
+
+## What this research now says to that person
+
+### AI assistants are most useful when they own a loop
+Good loops from the transcripts included:
+- inbox triage
+- research and synthesis
+- content drafting
+- review preparation
+- checking live artifacts and returning the exact link
+
+### The core setup is surprisingly small
+A practical beginner setup usually needs only:
+- one intake surface
+- one memory/source-of-truth document
+- one clear definition of done
+- one rule for when to ask a human
+- one rule for what must be verified before reporting success
+
+### The best first instructions are operational
+If I had to give a beginner the first version of an assistant operating contract, it would be:
+- do one task at a time
+- do not claim success without checking the result
+- include the exact file or link in the completion message
+- ask for help only when blocked
+- keep updates short and only send them on real change
+
+### The first serious upgrade is memory, not more tools
+The transcripts repeatedly showed that written memory improved results more reliably than adding more cleverness.
+Useful memory included:
+- preferences
+- recurring workflows
+- style guides
+- known gaps
+- operating rules
+
+### The second serious upgrade is review
+If the work matters, the assistant should not jump straight from draft to "done."
+The practical ladder is:
+- draft
+- review-ready
+- final
+
+### The most common beginner mistake
+Giving the assistant too much scope too early.
+That usually creates wandering, vague progress, and fake completion.
+
+## Tactical starter recipe
+
+### Step 1: pick one annoying recurring task
+Examples:
+- triage one inbox
+- summarize one research stream
+- manage one content workflow
+- prepare one review queue
+
+### Step 2: define the output
+Examples:
+- bullet summary
+- spreadsheet row
+- draft post
+- updated file
+- reviewed page with direct link
+
+### Step 3: define done
+Examples:
+- summary posted with 3 clear recommendations
+- draft saved to the repo and linked
+- page updated and verified on the live path
+- comments collected and grouped into next actions
+
+### Step 4: define verification
+Examples:
+- open the page
+- check the exact log
+- confirm the file exists
+- confirm the ID matches
+- confirm the channel is wired correctly
+
+### Step 5: define escalation
+Examples:
+- ask human before sending external messages
+- ask human if the output is ambiguous
+- ask human if a credential or approval is required
+
+## Most transferable lessons from the transcripts
+- smaller scope beats bigger ambition
+- verification beats eloquence
+- direct links beat vague status
+- written memory beats implied memory
+- reviewable beats supposedly finished
+- routing rules matter as much as prompts
+
+## Best use of this file
+Use it as the bridge between the research packet and publishable content aimed at people who are curious about agentic systems but do not yet live inside them.

--- a/research/2026-04-16-discord-instruction-lessons/digest.md
+++ b/research/2026-04-16-discord-instruction-lessons/digest.md
@@ -1,93 +1,128 @@
-# Digest: What We Learned from Discord About Better Instructions
+# Digest: What This Shows a Beginner About Setting Up an Actually Useful AI Assistant
 
 ## Executive summary
-Across Discord, the best improvements came from converting general preferences into hard operating rules.
+The biggest lesson from the Discord transcripts is not just how we improved instructions internally.
 
-The system got better when we made these shifts:
-- from helpful-sounding to execution-specific
-- from progress reporting to artifact shipping
-- from guessing to verifying
-- from broad delegation to constrained delegation
-- from implicit channel behavior to explicit wiring and mention rules
+It is that an AI assistant becomes dramatically more useful when you stop treating it like a chatbot and start giving it a small operating environment:
+- a place to receive work
+- a place to store memory
+- a clear definition of done
+- a few hard rules about verification, updates, and scope
 
-## Most important lessons, compressed
+That is the beginner-friendly frame.
+The interesting story is not "we tuned the prompts."
+The interesting story is "we discovered the practical rules that make this usable in real life."
 
-- Replace vague instructions with executable ones.
-- Done should mean usable, verified, and linked.
-- Debug from logs and live paths, not confidence.
-- Smaller context produces better delegated work.
-- Wandering is a real failure mode.
-- Review-ready should be treated as a separate state.
-- Explicit IDs beat implied integrations.
-- Channel setup is operational work.
-- Voice systems improve content quality.
-- The best lessons should be committed into the operating files.
+## What a newcomer should take away
+
+### 1. Start with one real workflow, not a giant AI life OS
+The best results came when the assistant owned a narrow but real job:
+- triaging an inbox
+- drafting content
+- checking a live page
+- managing a review loop
+
+This suggests a beginner should not start with ten automations.
+They should start with one annoying recurring task.
+
+### 2. The first thing to set up is not intelligence, it is clarity
+The assistant improved when the instructions became operational:
+- what counts as done
+- what must be verified
+- when to update the user
+- what not to do without confirmation
+
+A newcomer should understand this fast: the assistant is only as useful as the operating contract around it.
+
+### 3. "Done" has to mean something concrete
+One of the clearest lessons across the logs was that progress updates are not outcomes.
+For practical use, done should usually mean:
+- the artifact exists
+- the link or file is included
+- the live path or output is verified
+- the next action is obvious
+
+### 4. Small scope is a superpower
+Many failures came from the assistant or delegate having too much room to roam.
+A beginner should aggressively narrow:
+- one task
+- one folder
+- one source of truth
+- one expected output
+
+### 5. Verification matters more than confidence
+The system got better when it checked:
+- actual session logs
+- actual live pages
+- actual runtime configuration
+- actual IDs and links
+
+For a new user, this is a huge practical lesson: do not reward confident summaries that were not checked.
+
+### 6. Human review should be designed in, not bolted on later
+The best content and curriculum flows improved when there was a real distinction between:
+- draft
+- review-ready
+- publish-ready
+
+That is a generalizable beginner lesson for anyone using AI in business or content.
+
+### 7. Memory should be simple and file-backed
+Another practical takeaway is that memory worked best when it was explicit:
+- notes
+- guides
+- logs
+- operating files
+
+Not mystical. Just written down.
+
+### 8. Channels and routing matter more than people expect
+A channel only became useful when it had:
+- a clear purpose
+- mention behavior
+- routing rules
+- confirmed connectivity
+
+That is a practical setup insight for anyone using Discord, Slack, email, or group chat as the front door for an assistant.
+
+## The beginner setup playbook hiding inside this research
+
+If I were extracting the most tactical beginner playbook from the transcripts, it would be this:
+
+1. Pick one recurring workflow that wastes time.
+2. Give the assistant one intake surface for that workflow.
+3. Create one memory file or doc for persistent context.
+4. Define done in a way that produces a usable artifact.
+5. Require verification for anything important.
+6. Require direct links or outputs in completion messages.
+7. Keep updates milestone-based, not constant.
+8. Keep task scope narrow so the assistant cannot wander.
+9. Add human review where stakes are real.
+10. When you learn a better rule, write it down and keep it.
 
 ## Best tweet-ready bullets
 
-- "Be helpful" is weak. "Ship it, verify it, link it" is strong.
-- Many agent failures are scope failures wearing a reasoning costume.
-- Docs-only fixes are fake fixes.
-- A status update should happen on start, milestone, blocker, or done. Not every five minutes.
-- The hardest part of AI ops is defining done honestly.
-- Review-ready and publish-ready are different states.
-- If a delegate stalls, read the log before you tell a story about why.
-- A new channel is not real until it is wired.
-- Voice quality improves when it becomes a tracked system, not a vibe.
-- If a lesson matters, commit it.
-
-## Channel-specific takeaways
-
-### `#cass-inbox`
-- intake surfaces need routing contracts
-- inbox handling needs deterministic workflow
-- style guides materially improve content fit
-
-### `#car-shopping`
-- separate verified facts from inference
-- admit unverified inventory plainly
-- synthesis beats link dumping
-
-### `#agent-improvements`
-- fix runtime behavior, not just docs
-- inspect actual logs
-- constrain scope
-- keep updates sparse and meaningful
-
-### `#general`
-- channel wiring and mention policy are first-class rules
-
-### `#knowledge-graphs`
-- stalls are often wandering
-- architecture should converge earlier
-- delegates need intervention rules
-
-### `#lesson-plans`
-- completeness is product quality
-- honest status is better than fake finish
-- teaching usability matters more than raw output volume
-
-### `#lesson-plans-2`
-- include direct links automatically
-- keep review-ready separate from publish-ready
-- make preview windows meaningful
-- use explicit Remarq IDs
-- define done as live and reviewable
-
-### `#chris-stories`
-- use gap tracking
-- avoid repeated prompts
-- use voice guides for narrative fidelity
-
-### `#remarq` and repo-backed changes
-- codify important lessons in git-backed operating files
+- The leap from chatbot to assistant starts with operating rules, not smarter vibes.
+- Most people do not need an AI life OS. They need one workflow that actually closes loops.
+- The first useful prompt is usually not a prompt. It is a definition of done.
+- If the assistant finishes without a usable link, file, or output, it probably did not finish.
+- A lot of agent failure is just too much scope.
+- Smaller work area, smaller task, better result.
+- Review-ready and publish-ready are different states. Treat them that way.
+- AI memory works best when it is explicit and file-backed, not magical.
+- Verification beats confidence.
+- If a lesson materially improves outcomes, write it into the operating system around the assistant.
 
 ## Long-form article count
-There are **12 strong long-form article candidates** supported by this review.
+There are still **12 strong long-form article candidates** here, but the better framing is now:
+- what becomes possible for a normal person
+- how to set it up practically
+- which rules matter first
+- how to avoid the obvious failure modes
 
-Top 5:
-1. Operational prompts beat aspirational prompts
-2. The real definition of done for AI-assisted work
-3. Most agent stalls are scope bugs, not reasoning bugs
-4. Docs-only fixes are fake fixes
-5. Review-ready vs publish-ready
+## Best first 5 articles to write with this framing
+1. What an AI assistant can actually do once it stops acting like a chatbot
+2. The 5 rules that make an AI assistant actually useful in real life
+3. How to set up your first agent without building a giant system
+4. The real definition of done for AI-assisted work
+5. How to keep an AI agent from wandering off into nonsense

--- a/research/2026-04-16-discord-instruction-lessons/digest.md
+++ b/research/2026-04-16-discord-instruction-lessons/digest.md
@@ -1,0 +1,93 @@
+# Digest: What We Learned from Discord About Better Instructions
+
+## Executive summary
+Across Discord, the best improvements came from converting general preferences into hard operating rules.
+
+The system got better when we made these shifts:
+- from helpful-sounding to execution-specific
+- from progress reporting to artifact shipping
+- from guessing to verifying
+- from broad delegation to constrained delegation
+- from implicit channel behavior to explicit wiring and mention rules
+
+## Most important lessons, compressed
+
+- Replace vague instructions with executable ones.
+- Done should mean usable, verified, and linked.
+- Debug from logs and live paths, not confidence.
+- Smaller context produces better delegated work.
+- Wandering is a real failure mode.
+- Review-ready should be treated as a separate state.
+- Explicit IDs beat implied integrations.
+- Channel setup is operational work.
+- Voice systems improve content quality.
+- The best lessons should be committed into the operating files.
+
+## Best tweet-ready bullets
+
+- "Be helpful" is weak. "Ship it, verify it, link it" is strong.
+- Many agent failures are scope failures wearing a reasoning costume.
+- Docs-only fixes are fake fixes.
+- A status update should happen on start, milestone, blocker, or done. Not every five minutes.
+- The hardest part of AI ops is defining done honestly.
+- Review-ready and publish-ready are different states.
+- If a delegate stalls, read the log before you tell a story about why.
+- A new channel is not real until it is wired.
+- Voice quality improves when it becomes a tracked system, not a vibe.
+- If a lesson matters, commit it.
+
+## Channel-specific takeaways
+
+### `#cass-inbox`
+- intake surfaces need routing contracts
+- inbox handling needs deterministic workflow
+- style guides materially improve content fit
+
+### `#car-shopping`
+- separate verified facts from inference
+- admit unverified inventory plainly
+- synthesis beats link dumping
+
+### `#agent-improvements`
+- fix runtime behavior, not just docs
+- inspect actual logs
+- constrain scope
+- keep updates sparse and meaningful
+
+### `#general`
+- channel wiring and mention policy are first-class rules
+
+### `#knowledge-graphs`
+- stalls are often wandering
+- architecture should converge earlier
+- delegates need intervention rules
+
+### `#lesson-plans`
+- completeness is product quality
+- honest status is better than fake finish
+- teaching usability matters more than raw output volume
+
+### `#lesson-plans-2`
+- include direct links automatically
+- keep review-ready separate from publish-ready
+- make preview windows meaningful
+- use explicit Remarq IDs
+- define done as live and reviewable
+
+### `#chris-stories`
+- use gap tracking
+- avoid repeated prompts
+- use voice guides for narrative fidelity
+
+### `#remarq` and repo-backed changes
+- codify important lessons in git-backed operating files
+
+## Long-form article count
+There are **12 strong long-form article candidates** supported by this review.
+
+Top 5:
+1. Operational prompts beat aspirational prompts
+2. The real definition of done for AI-assisted work
+3. Most agent stalls are scope bugs, not reasoning bugs
+4. Docs-only fixes are fake fixes
+5. Review-ready vs publish-ready


### PR DESCRIPTION
## Summary
Adds a separate research packet summarizing Discord session-log lessons about instruction updates, operating rules, tweet cards, and long-form article opportunities.

## Includes
- scope and method
- per-channel summaries
- cross-cutting lessons
- tweet-card digest
- long-form article opportunities
- single-file digest

## Notes
This came from reviewing archived and current Discord session transcripts from 2026-02-27 through 2026-04-16.